### PR TITLE
fix: Compare commits from the latest release.

### DIFF
--- a/pkg/provider/github.go
+++ b/pkg/provider/github.go
@@ -81,13 +81,15 @@ func (repo *GitHubRepository) GetCommits(fromSha, toSha string) ([]*semrel.RawCo
 		SHA:         toSha,
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
+
 	done := false
 	for {
-		commits, resp, err := repo.client.Repositories.ListCommits(context.Background(), repo.owner, repo.repo, opts)
+		commits, resp, err := repo.client.Repositories.CompareCommits(context.Background(), repo.owner, repo.repo, fromSha, toSha)
 		if err != nil {
 			return nil, err
 		}
-		for _, commit := range commits {
+
+		for _, commit := range commits.Commits {
 			sha := commit.GetSHA()
 			if sha == fromSha {
 				done = true

--- a/pkg/provider/github_test.go
+++ b/pkg/provider/github_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/go-semantic-release/semantic-release/v2/pkg/provider"
@@ -100,8 +101,11 @@ func githubHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(GITHUB_REPO)
 		return
 	}
-	if r.Method == "GET" && r.URL.Path == "/repos/owner/test-repo/commits" {
-		toSha := r.URL.Query().Get("sha")
+	if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/owner/test-repo/compare/") {
+
+		li := strings.LastIndex(r.URL.Path, "/")
+		arr := strings.Split(r.URL.Path[li+1:], "...")
+		toSha := arr[1]
 		skip := 0
 		for i, commit := range GITHUB_COMMITS {
 			if commit.GetSHA() == toSha {
@@ -109,7 +113,7 @@ func githubHandler(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
-		json.NewEncoder(w).Encode(GITHUB_COMMITS[skip:])
+		json.NewEncoder(w).Encode(github.CommitsComparison{Commits: GITHUB_COMMITS[skip:]})
 		return
 	}
 	if r.Method == "GET" && r.URL.Path == "/repos/owner/test-repo/git/matching-refs/tags" {


### PR DESCRIPTION
Fixes #5 

I have run into a number of situation as describe in the Issue #5. Comparing commits ensures that you get all the commits from the latest release and the current sha. 